### PR TITLE
Add seeder for default data health rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Minimal Composer/Laravel package that runs **business-data health checks** insid
   - `DUE_OVER_MAX` — dues charge > `multiplier × typical_due` (default: 2 × 70).
   - `DUP_CHARGES` — same member has ≥2 dues charges in the same month.
 - Stores deduped, durable results in `dhp_results` (`open`/`resolved`).
-- Seeds default rules into `dhp_rules` on first run.
+- Includes a seeder to insert default rules into `dhp_rules`.
 - (Optional) Exposes a Prometheus-style endpoint: `/metrics/data-health-poc`.
 
 Use it on a fresh Laravel app or drop it into your ERP, then customize.
@@ -106,6 +106,12 @@ Run package migrations (creates `dhp_rules`, `dhp_results`):
 php artisan migrate
 ```
 
+Then seed the default rule rows:
+
+```bash
+php artisan db:seed --class="UnionImpact\\DataHealthPoc\\Database\\Seeders\\DataHealthPocSeeder"
+```
+
 That’s it. No config files in the PoC.
 
 ---
@@ -131,7 +137,7 @@ INSERT INTO charges (member_id, period_ym, type, amount) VALUES
 php artisan data-health-poc:run
 ```
 
-- First run **seeds** default rules into `dhp_rules`.
+- Uses rule rows in `dhp_rules` (seeded via `DataHealthPocSeeder`).
 - Results written to `dhp_results` with `status = open`.
 - Re-running will mark stale rows as `resolved` if violations disappear.
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,10 @@
   "autoload": {
     "psr-4": {
       "UnionImpact\\DataHealthPoc\\": "src/"
-    }
+    },
+    "classmap": [
+      "database/seeders"
+    ]
   },
   "extra": {
     "laravel": {

--- a/database/seeders/DataHealthPocSeeder.php
+++ b/database/seeders/DataHealthPocSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace UnionImpact\DataHealthPoc\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use UnionImpact\DataHealthPoc\Models\Rule;
+
+class DataHealthPocSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Rule::firstOrCreate(
+            ['code' => 'DUE_OVER_MAX'],
+            [
+                'name'    => 'Dues amount exceeds maximum',
+                'options' => ['default_due' => 70, 'multiplier' => 2],
+                'enabled' => true,
+            ]
+        );
+
+        Rule::firstOrCreate(
+            ['code' => 'DUP_CHARGES'],
+            [
+                'name'    => 'Duplicate charges in same month',
+                'options' => new \stdClass(),
+                'enabled' => true,
+            ]
+        );
+    }
+}

--- a/src/Console/RunDataHealthCommand.php
+++ b/src/Console/RunDataHealthCommand.php
@@ -14,9 +14,6 @@ class RunDataHealthCommand extends Command
 
     public function handle()
     {
-        // Ensure rule rows exist (seed defaults if missing)
-        $this->seedDefaults();
-
         $rules = Rule::query()->where('enabled', true)->get()->keyBy('code');
 
         // Map of rule code => class
@@ -76,16 +73,4 @@ class RunDataHealthCommand extends Command
         return self::SUCCESS;
     }
 
-    protected function seedDefaults(): void
-    {
-        Rule::firstOrCreate(
-            ['code' => 'DUE_OVER_MAX'],
-            ['name' => 'Dues amount exceeds maximum', 'options' => ['default_due' => 70, 'multiplier' => 2], 'enabled' => true]
-        );
-
-        Rule::firstOrCreate(
-            ['code' => 'DUP_CHARGES'],
-            ['name' => 'Duplicate charges in same month', 'options' => new \stdClass(), 'enabled' => true]
-        );
-    }
 }


### PR DESCRIPTION
## Summary
- add a `DataHealthPocSeeder` to populate default rule rows
- remove inline default rule seeding from `RunDataHealthCommand`
- document running the seeder after migrations

## Testing
- `php -l database/seeders/DataHealthPocSeeder.php`
- `php -l src/Console/RunDataHealthCommand.php`
- `composer validate --no-check-all --strict`
- `composer dump-autoload`


------
https://chatgpt.com/codex/tasks/task_e_68a197977f90832ebb336b5f79f75559