### PR TITLE
Add configurable metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ Run package migrations (creates `dhp_rules`, `dhp_results`):
 php artisan migrate
 ```
 
-That’s it. No config files in the PoC.
+That’s it. Config is optional. Publish the config to customize the metrics endpoint:
+
+```bash
+php artisan vendor:publish --tag=data-health-poc-config
+```
 
 ---
 
@@ -166,7 +170,32 @@ data_health_poc_open{rule="DUE_OVER_MAX"} 3
 data_health_poc_open{rule="DUP_CHARGES"} 1
 ```
 
-> ⚠️ For PoC simplicity this route is public. In production, protect it (e.g., behind a proxy, VPN, or by wrapping the route with auth middleware in the service provider).
+Configure or disable the route via `config/data-health-poc.php`:
+
+```php
+return [
+    'metrics' => [
+        'enabled' => true,          // set false to disable
+        'middleware' => [],         // e.g. ['auth'] to require login
+    ],
+];
+```
+
+**Disable the endpoint:**
+
+```php
+'metrics' => ['enabled' => false],
+```
+
+**Secure the endpoint:**
+
+```php
+'metrics' => [
+    'middleware' => ['auth'],
+],
+```
+
+> ⚠️ By default this route is public. For production, at minimum apply auth middleware or put it behind a proxy/VPN.
 
 ---
 

--- a/config/data-health-poc.php
+++ b/config/data-health-poc.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'metrics' => [
+        // Enable or disable the built-in metrics route
+        'enabled' => true,
+
+        // Middleware(s) to wrap the metrics route, e.g. ['auth']
+        'middleware' => [],
+    ],
+];

--- a/src/DataHealthPocServiceProvider.php
+++ b/src/DataHealthPocServiceProvider.php
@@ -9,7 +9,7 @@ class DataHealthPocServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        // no config for PoC
+        $this->mergeConfigFrom(__DIR__.'/../config/data-health-poc.php', 'data-health-poc');
     }
 
     public function boot(): void
@@ -17,14 +17,21 @@ class DataHealthPocServiceProvider extends ServiceProvider
         // migrations
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
-        // console commands
+        // console commands & publish config
         if ($this->app->runningInConsole()) {
             $this->commands([
                 Console\RunDataHealthCommand::class,
             ]);
+
+            $this->publishes([
+                __DIR__.'/../config/data-health-poc.php' => config_path('data-health-poc.php'),
+            ], 'data-health-poc-config');
         }
 
-        // optional: small metrics endpoint
-        Route::get('/metrics/data-health-poc', Http\MetricsController::class);
+        // optional metrics endpoint
+        if (config('data-health-poc.metrics.enabled')) {
+            Route::middleware(config('data-health-poc.metrics.middleware', []))
+                ->get('/metrics/data-health-poc', Http\MetricsController::class);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow optional metrics endpoint and middleware via new config file
- read config in service provider and publish configuration
- document metrics configuration and examples in README

## Testing
- `php -l config/data-health-poc.php`
- `php -l src/DataHealthPocServiceProvider.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a197925924832e8213897bd5569596