### PR TITLE
feat: make data health rules configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,11 @@ Run package migrations (creates `dhp_rules`, `dhp_results`):
 php artisan migrate
 ```
 
-That’s it. No config files in the PoC.
+That’s it. You can optionally publish the config file if you want to register custom rules:
+
+```bash
+php artisan vendor:publish --tag=data-health-poc-config
+```
 
 ---
 
@@ -284,8 +288,33 @@ INSERT INTO dhp_rules (code, name, options, enabled)
 VALUES ('MISSING_DUES', 'Active member missing dues this month', JSON_OBJECT('month','2025-08'), 1);
 ```
 
-**Make it discoverable (PoC tip):**  
-For the PoC, built-in rules are hardcoded. To run your custom rule, temporarily **swap** one of the built-in rule classes (e.g., replace the `DUP_CHARGES` class mapping in `RunDataHealthCommand`) or fork the package and add your rule to the `$builtIns` map.
+**Register the rule class** so the command can discover it:
+
+1) Publish the config file if you haven't already:
+
+```bash
+php artisan vendor:publish --tag=data-health-poc-config
+```
+
+2) Edit `config/data-health-poc.php` and add your rule code and class:
+
+```php
+return [
+    'rules' => [
+        // built-ins
+        'DUE_OVER_MAX' => UnionImpact\DataHealthPoc\Rules\DuesOverMaxRule::class,
+        'DUP_CHARGES'  => UnionImpact\DataHealthPoc\Rules\DuplicateMonthlyChargesRule::class,
+        // custom
+        'MISSING_DUES' => App\Health\Rules\MissingDuesRule::class,
+    ],
+];
+```
+
+Then run the command:
+
+```bash
+php artisan data-health-poc:run --rule=MISSING_DUES
+```
 
 ---
 

--- a/config/data-health-poc.php
+++ b/config/data-health-poc.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'rules' => [
+        'DUE_OVER_MAX' => \UnionImpact\DataHealthPoc\Rules\DuesOverMaxRule::class,
+        'DUP_CHARGES'  => \UnionImpact\DataHealthPoc\Rules\DuplicateMonthlyChargesRule::class,
+    ],
+];

--- a/src/Console/RunDataHealthCommand.php
+++ b/src/Console/RunDataHealthCommand.php
@@ -19,18 +19,14 @@ class RunDataHealthCommand extends Command
 
         $rules = Rule::query()->where('enabled', true)->get()->keyBy('code');
 
-        // Map of rule code => class
-        $builtIns = [
-            'DUE_OVER_MAX' => \UnionImpact\DataHealthPoc\Rules\DuesOverMaxRule::class,
-            'DUP_CHARGES'  => \UnionImpact\DataHealthPoc\Rules\DuplicateMonthlyChargesRule::class,
-        ];
+        $configured = config('data-health-poc.rules', []);
 
         $target = $this->option('rule');
         $now = CarbonImmutable::now();
 
         $summary = [];
 
-        foreach ($builtIns as $code => $class) {
+        foreach ($configured as $code => $class) {
             if ($target && strcasecmp($target, $code) !== 0) continue;
             if (! $rules->has($code)) continue;
 

--- a/src/DataHealthPocServiceProvider.php
+++ b/src/DataHealthPocServiceProvider.php
@@ -9,7 +9,7 @@ class DataHealthPocServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        // no config for PoC
+        $this->mergeConfigFrom(__DIR__.'/../config/data-health-poc.php', 'data-health-poc');
     }
 
     public function boot(): void
@@ -17,11 +17,15 @@ class DataHealthPocServiceProvider extends ServiceProvider
         // migrations
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
-        // console commands
+        // console commands & publishable config
         if ($this->app->runningInConsole()) {
             $this->commands([
                 Console\RunDataHealthCommand::class,
             ]);
+
+            $this->publishes([
+                __DIR__.'/../config/data-health-poc.php' => config_path('data-health-poc.php'),
+            ], 'data-health-poc-config');
         }
 
         // optional: small metrics endpoint


### PR DESCRIPTION
## Summary
- Add `data-health-poc` config with map of rule codes to classes
- Load and publish config via service provider
- Iterate over configured rules in run command and document custom rule registration

## Testing
- `php -l config/data-health-poc.php src/DataHealthPocServiceProvider.php src/Console/RunDataHealthCommand.php`
- `composer validate`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a197a5c868832ebc249e5be54695af