### PR TITLE
Add metrics endpoint test

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/MetricsEndpointTest.php
+++ b/tests/MetricsEndpointTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use UnionImpact\DataHealthPoc\Models\Rule;
+
+it('exposes open violations via metrics endpoint', function () {
+    Rule::create([
+        'code' => 'DUE_OVER_MAX',
+        'name' => 'Dues amount exceeds maximum',
+        'options' => ['default_due' => 70, 'multiplier' => 2],
+        'enabled' => true,
+    ]);
+
+    DB::table('members')->insert([
+        'id' => 1,
+        'status' => 'active',
+        'typical_due' => 50,
+    ]);
+
+    DB::table('charges')->insert([
+        'id' => 1,
+        'member_id' => 1,
+        'period_ym' => '2025-01',
+        'type' => 'dues',
+        'amount' => 150,
+    ]);
+
+    $this->artisan('data-health-poc:run')->assertExitCode(0);
+
+    $response = $this->get('/metrics/data-health-poc');
+    $response->assertStatus(200);
+    $response->assertSee('# HELP data_health_poc_open', false);
+    $response->assertSee('data_health_poc_open{rule="DUE_OVER_MAX"}', false);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,7 @@
+<?php
+
+use UnionImpact\DataHealthPoc\Tests\TestCase;
+
+require_once __DIR__.'/TestCase.php';
+
+uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace UnionImpact\DataHealthPoc\Tests;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase as Orchestra;
+use UnionImpact\DataHealthPoc\DataHealthPocServiceProvider;
+
+class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app)
+    {
+        return [DataHealthPocServiceProvider::class];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $app['config']->set('data-health-poc.rules', [
+            'DUE_OVER_MAX' => \UnionImpact\DataHealthPoc\Rules\DuesOverMaxRule::class,
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('members', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('status')->default('active');
+            $table->decimal('typical_due', 10, 2)->nullable();
+        });
+
+        Schema::create('charges', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('member_id');
+            $table->string('period_ym', 7);
+            $table->string('type');
+            $table->decimal('amount', 10, 2);
+        });
+
+        $this->artisan('migrate');
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('charges');
+        Schema::dropIfExists('members');
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## Summary
- configure in-memory test environment for package
- test metrics endpoint returns counts for open violations

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a19af25818832eb18b5edd92e17c4e