### PR TITLE
Disable metrics route by default and document enabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Minimal Composer/Laravel package that runs **business-data health checks** insid
   - `DUP_CHARGES` — same member has ≥2 dues charges in the same month.
 - Stores deduped, durable results in `dhp_results` (`open`/`resolved`).
 - Includes a seeder to insert default rules into `dhp_rules`.
-- (Optional) Exposes a Prometheus-style endpoint: `/metrics/data-health-poc`.
+- (Optional) Exposes a Prometheus-style endpoint: `/metrics/data-health-poc` (disabled by default).
 
 Use it on a fresh Laravel app or drop it into your ERP, then customize.
 
@@ -174,7 +174,7 @@ The `test` Composer script runs Pest using an in-memory SQLite database provided
 
 ## Metrics endpoint (optional)
 
-A minimal Prometheus endpoint is available at:
+A minimal Prometheus endpoint is available at (disabled by default):
 
 ```
 GET /metrics/data-health-poc
@@ -188,32 +188,17 @@ data_health_poc_open{rule="DUE_OVER_MAX"} 3
 data_health_poc_open{rule="DUP_CHARGES"} 1
 ```
 
-Configure or disable the route via `config/data-health-poc.php`:
+Enable and secure the route via `config/data-health-poc.php`:
 
 ```php
 return [
     'metrics' => [
-        'enabled' => true,          // set false to disable
-        'middleware' => [],         // e.g. ['auth'] to require login
+        'enabled' => true,          // set true to expose the route
+        'middleware' => ['auth.basic'], // recommended: protect with auth
     ],
 ];
 ```
-
-**Disable the endpoint:**
-
-```php
-'metrics' => ['enabled' => false],
-```
-
-**Secure the endpoint:**
-
-```php
-'metrics' => [
-    'middleware' => ['auth'],
-],
-```
-
-> ⚠️ By default this route is public. For production, at minimum apply auth middleware or put it behind a proxy/VPN.
+> ⚠️ Enabling this route exposes internal health data. Always protect it with authentication middleware or put it behind a proxy/VPN.
 
 ---
 

--- a/config/data-health-poc.php
+++ b/config/data-health-poc.php
@@ -4,9 +4,9 @@ return [
 
     'metrics' => [
         // Enable or disable the built-in metrics route
-        'enabled' => true,
+        'enabled' => false,
 
-        // Middleware(s) to wrap the metrics route, e.g. ['auth']
+        // Middleware(s) to wrap the metrics route, e.g. ['auth.basic']
         'middleware' => [],
 
     ],

--- a/tests/MetricsEndpointTest.php
+++ b/tests/MetricsEndpointTest.php
@@ -1,7 +1,13 @@
 <?php
 
 use Illuminate\Support\Facades\DB;
+use UnionImpact\DataHealthPoc\DataHealthPocServiceProvider;
 use UnionImpact\DataHealthPoc\Models\Rule;
+
+beforeEach(function () {
+    config(['data-health-poc.metrics.enabled' => true]);
+    (new DataHealthPocServiceProvider($this->app))->boot();
+});
 
 it('exposes open violations via metrics endpoint', function () {
     Rule::create([

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,4 +4,4 @@ use UnionImpact\DataHealthPoc\Tests\TestCase;
 
 require_once __DIR__.'/TestCase.php';
 
-uses(TestCase::class)->in(__DIR__);
+uses(TestCase::class)->in('MetricsEndpointTest.php');


### PR DESCRIPTION
## Summary
- Disable metrics endpoint by default and note recommended auth middleware in config
- Document how to enable and secure metrics route in README
- Explicitly enable metrics route in tests and scope Pest setup accordingly

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a19fbfc298832ea013a867e0d4cf3b