### PR TITLE
chore: ignore dependencies and build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/vendor/
+/node_modules/
+/.idea/
+/build/
+/dist/
+/coverage/
+# general build artifacts
+*.log
+*.tmp
+*.cache
+*.out


### PR DESCRIPTION
## Summary
- add .gitignore to avoid committing vendor, node_modules, IDE config, and build output

## Testing
- `composer test` *(fails: Test case `RuleSeedingTestCase` can not be used because RuleSeedingTest.php already uses a different test case)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a0a25460832ea0e9c1b5a1e4ec5d