### PR TITLE
Add default rule mappings and clean up tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,25 @@ SELECT * FROM dhp_rules;
 php artisan data-health-poc:run --rule=DUE_OVER_MAX
 ```
 
+### Rule configuration
+
+Rule discovery uses the `rules` array in `config/data-health-poc.php`, which maps rule codes to their classes. The package ships with defaults for its built-in checks:
+
+```php
+'rules' => [
+    'DUE_OVER_MAX' => UnionImpact\DataHealthPoc\Rules\DuesOverMaxRule::class,
+    'DUP_CHARGES'  => UnionImpact\DataHealthPoc\Rules\DuplicateMonthlyChargesRule::class,
+],
+```
+
+Publish the config to register additional rules:
+
+```bash
+php artisan vendor:publish --tag=data-health-poc-config
+```
+
+Then add your custom mappings to the `rules` array. See [Adding your own rules](#adding-your-own-rules) for a full example.
+
 ---
 
 ## Testing

--- a/config/data-health-poc.php
+++ b/config/data-health-poc.php
@@ -2,6 +2,11 @@
 
 return [
 
+    'rules' => [
+        'DUE_OVER_MAX' => \UnionImpact\DataHealthPoc\Rules\DuesOverMaxRule::class,
+        'DUP_CHARGES'  => \UnionImpact\DataHealthPoc\Rules\DuplicateMonthlyChargesRule::class,
+    ],
+
     'metrics' => [
         // Enable or disable the built-in metrics route
         'enabled' => false,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,7 +21,7 @@ parameters:
 		-
 			message: '#^Undefined variable\: \$this$#'
 			identifier: variable.undefined
-			count: 2
+			count: 3
 			path: tests/MetricsEndpointTest.php
 
 		-

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -8,4 +8,3 @@ uses(TestCase::class)->in(
     __DIR__.'/RunDataHealthCommandTest.php',
     __DIR__.'/MetricsEndpointTest.php'
 );
-

--- a/tests/RuleSeedingTest.php
+++ b/tests/RuleSeedingTest.php
@@ -5,8 +5,6 @@ use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as Orchestra;
 use UnionImpact\DataHealthPoc\Database\Seeders\DataHealthPocSeeder;
 use UnionImpact\DataHealthPoc\Models\Rule;
-use UnionImpact\DataHealthPoc\Rules\DuesOverMaxRule;
-use UnionImpact\DataHealthPoc\Rules\DuplicateMonthlyChargesRule;
 
 class RuleSeedingTestCase extends Orchestra
 {
@@ -24,10 +22,6 @@ class RuleSeedingTestCase extends Orchestra
             'prefix' => '',
         ]);
 
-        $app['config']->set('data-health-poc.rules', [
-            'DUE_OVER_MAX' => DuesOverMaxRule::class,
-            'DUP_CHARGES'  => DuplicateMonthlyChargesRule::class,
-        ]);
     }
 }
 

--- a/tests/RunDataHealthCommandTest.php
+++ b/tests/RunDataHealthCommandTest.php
@@ -18,10 +18,6 @@ class RunDataHealthCommandTest extends TestCase
             'database' => ':memory:',
             'prefix' => '',
         ]);
-        $app['config']->set('data-health-poc.rules', [
-            'DUE_OVER_MAX' => \UnionImpact\DataHealthPoc\Rules\DuesOverMaxRule::class,
-            'DUP_CHARGES'  => \UnionImpact\DataHealthPoc\Rules\DuplicateMonthlyChargesRule::class,
-        ]);
     }
 
     protected function getPackageProviders($app)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,9 +23,6 @@ class TestCase extends Orchestra
             'prefix' => '',
         ]);
 
-        $app['config']->set('data-health-poc.rules', [
-            'DUE_OVER_MAX' => \UnionImpact\DataHealthPoc\Rules\DuesOverMaxRule::class,
-        ]);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
## Summary
- add built-in rule mapping to config
- rely on default rule mapping in test setup
- document rule configuration and custom registration in README

## Testing
- `composer lint`
- `composer phpstan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a1a3161e5c832e89001ae151ba7e1b