### PR TITLE
Use array for default options in DataHealthPocSeeder

### DIFF
--- a/database/seeders/DataHealthPocSeeder.php
+++ b/database/seeders/DataHealthPocSeeder.php
@@ -22,7 +22,7 @@ class DataHealthPocSeeder extends Seeder
             ['code' => 'DUP_CHARGES'],
             [
                 'name'    => 'Duplicate charges in same month',
-                'options' => new \stdClass(),
+                'options' => [],
                 'enabled' => true,
             ]
         );


### PR DESCRIPTION
## Summary
- replace `new \stdClass()` with `[]` when seeding DUP_CHARGES rule

## Testing
- `vendor/bin/testbench migrate --seed --seeder="UnionImpact\\DataHealthPoc\\Database\\Seeders\\DataHealthPocSeeder"`
- `vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_68a1a51546f8832e864caa878ab80931