### PR TITLE
Add phpunit and collision dev tooling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     "pestphp/pest": "^2.0",
     "pestphp/pest-plugin-laravel": "^2.0",
     "friendsofphp/php-cs-fixer": "^3.86",
-    "phpstan/phpstan": "^2.1"
+    "phpstan/phpstan": "^2.1",
+    "phpunit/phpunit": "^10.5",
+    "nunomaduro/collision": "^8.4"
   },
   "autoload": {
     "psr-4": {
@@ -31,9 +33,10 @@
   },
   "scripts": {
     "test": "pest",
-    "lint": "php-cs-fixer fix --dry-run --diff",
-    "lint:fix": "php-cs-fixer fix",
-    "phpstan": "phpstan analyse --memory-limit=1G"
+    "test:cov": "pest --coverage --min=70 --coverage-html=coverage/html --coverage-clover=coverage/clover.xml",
+    "lint": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --dry-run --diff",
+    "lint:fix": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix",
+    "stan": "phpstan analyse --memory-limit=1G"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a255f5ed9ac38cf55286cfe247aed0ec",
+    "content-hash": "57feb5ad1ad7626b719483f4cd981ba0",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
## Summary
- add phpunit/phpunit and nunomaduro/collision dev dependencies
- add testing, linting and static-analysis Composer scripts

## Testing
- `composer install --no-interaction`
- `composer test`
- `composer stan`
- `composer lint`
- `XDEBUG_MODE=coverage composer test:cov` *(fails: No code coverage driver is available)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a833edf4832eab4c6fe86771aeb0