### PR TITLE
chore: add editor and git attributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.php]
+indent_style = space
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+
+/.github              export-ignore
+/tests                export-ignore
+/phpstan.neon         export-ignore
+/phpstan-baseline.neon export-ignore
+/phpunit.xml          export-ignore
+/composer.lock        export-ignore
+/.editorconfig        export-ignore
+/.gitattributes       export-ignore
+/.gitignore           export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build/
 /dist/
 /coverage/
+coverage.xml
 # general build artifacts
 *.log
 *.tmp

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
   "scripts": {
     "test": "pest",
     "test:cov": "pest --coverage --min=70 --coverage-html=coverage/html --coverage-clover=coverage/clover.xml",
-    "lint": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --dry-run --diff",
-    "lint:fix": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix",
+    "lint": "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --diff",
+    "lint:fix": "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix",
     "stan": "phpstan analyse --memory-limit=1G"
   },
   "config": {


### PR DESCRIPTION
## Summary
- add PSR-12 `.editorconfig` with LF endings
- normalize line endings and export-ignore dev files via `.gitattributes`
- ignore coverage artifacts and ensure newline in `.gitignore`
- run php-cs-fixer through vendor bin with `PHP_CS_FIXER_IGNORE_ENV=1`

## Testing
- `composer lint`
- `composer test`
- `composer stan`


------
https://chatgpt.com/codex/tasks/task_e_68a1a9c984dc832ead09f96dfdc79ca5