### PR TITLE
docs: clarify testing & ci instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Minimal Composer/Laravel package that runs **business-data health checks** insid
    - [Git (GitHub/GitLab) repo](#option-b-git-vcs-repo)  
 5. [Migrate database](#migrate-database)
 6. [Quick start](#quick-start)
-7. [Testing](#testing)
+7. [Testing & CI](#testing--ci)
 8. [Metrics endpoint (optional)](#metrics-endpoint-optional)
 9. [Tuning thresholds](#tuning-thresholds)
 10. [Scheduling](#scheduling)
@@ -178,7 +178,7 @@ Then add your custom mappings to the `rules` array. See [Adding your own rules](
 
 ---
 
-## Testing
+## Testing & CI
 
 Install development dependencies:
 
@@ -186,18 +186,13 @@ Install development dependencies:
 composer install
 ```
 
-Run code style checks, static analysis, and the test suite:
+Run code style checks, static analysis, the test suite, and coverage:
 
 ```bash
-composer lint   # PHP-CS-Fixer
-composer stan   # PHPStan
-composer test   # Pest
-```
-
-Generate coverage (fails if below 70%):
-
-```bash
-composer test:cov
+composer lint      # PHP-CS-Fixer
+composer stan      # PHPStan
+composer test      # Pest
+composer test:cov  # Pest with coverage (fails if below 70%)
 ```
 
 HTML coverage reports are written to `coverage/html/index.html`; open this file in a browser to view the report.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,43 +1,45 @@
 parameters:
-	ignoreErrors:
-		-
-			message: '#^Call to an undefined static method UnionImpact\\DataHealthPoc\\Models\\Result\:\:updateOrCreate\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: src/Console/RunDataHealthCommand.php
+        ignoreErrors:
+                -
+                        message: '#^Call to an undefined static method UnionImpact\\DataHealthPoc\\Models\\Result\:\:updateOrCreate\(\)\.$#'
+                        identifier: staticMethod.notFound
+                        count: 1
+                        path: src/Console/RunDataHealthCommand.php
 
-		-
-			message: '#^Call to an undefined static method UnionImpact\\DataHealthPoc\\Models\\Result\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: src/Console/RunDataHealthCommand.php
+                -
+                        message: '#^Call to an undefined static method UnionImpact\\DataHealthPoc\\Models\\Result\:\:where\(\)\.$#'
+                        identifier: staticMethod.notFound
+                        count: 2
+                        path: src/Console/RunDataHealthCommand.php
 
-		-
-			message: '#^Call to an undefined static method UnionImpact\\DataHealthPoc\\Models\\Rule\:\:create\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: tests/MetricsEndpointTest.php
+                -
+                        message: '#^Call to an undefined static method UnionImpact\\DataHealthPoc\\Models\\Rule\:\:create\(\)\.$#'
+                        identifier: staticMethod.notFound
+                        count: 1
+                        path: tests/Feature/MetricsEndpointTest.php
 
-		-
-			message: '#^Undefined variable\: \$this$#'
-			identifier: variable.undefined
-			count: 3
-			path: tests/MetricsEndpointTest.php
+                -
+                        message: '#^Undefined variable: \$this$#'
+                        identifier: variable.undefined
+                        count: 3
+                        path: tests/Feature/MetricsEndpointTest.php
 
-		-
-			message: '#^Call to an undefined static method UnionImpact\\DataHealthPoc\\Models\\Rule\:\:where\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: tests/RuleSeedingTest.php
+                -
+                        message: '#^Call to an undefined static method UnionImpact\\DataHealthPoc\\Models\\Rule\:\:where\(\)\.$#'
+                        identifier: staticMethod.notFound
+                        count: 2
+                        path: tests/Database/RuleSeedingTest.php
 
-		-
-			message: '#^Undefined variable\: \$this$#'
-			identifier: variable.undefined
-			count: 3
-			path: tests/RuleSeedingTest.php
+                -
+                        message: '#^Undefined variable: \$this$#'
+                        identifier: variable.undefined
+                        count: 3
+                        path: tests/Database/RuleSeedingTest.php
 
-		-
-			message: '#^Call to an undefined static method UnionImpact\\DataHealthPoc\\Models\\Result\:\:count\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 2
-			path: tests/RunDataHealthCommandTest.php
+                -
+                        message: '#^Call to an undefined static method UnionImpact\\DataHealthPoc\\Models\\Result\:\:count\(\)\.$#'
+                        identifier: staticMethod.notFound
+                        count: 2
+                        path: tests/Integration/RunDataHealthCommandTest.php
+
+                

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,4 +1,3 @@
 <?php
 
 require __DIR__.'/../pest.php';
-


### PR DESCRIPTION
## Summary
- rename documentation section to "Testing & CI"
- document `composer stan` and `composer test:cov` usage
- align phpstan baseline paths with existing tests and tidy tests/Pest.php

## Testing
- `composer lint`
- `composer stan`
- `composer test`
- `composer test:cov` *(fails: No code coverage driver is available)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b07d6198832eae426fce3bc642a3