### PR TITLE
Disable risky php-cs-fixer rules

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,7 +8,7 @@ $finder = PhpCsFixer\Finder::create()
     ->ignoreVCS(true);
 
 return (new PhpCsFixer\Config())
-    ->setRiskyAllowed(true)
+    ->setRiskyAllowed(false)
     ->setRules([
         '@PSR12' => true,
         'array_syntax' => ['syntax' => 'short'],


### PR DESCRIPTION
## Summary
- Avoid running risky php-cs-fixer rules by disallowing them in configuration

## Testing
- `composer lint` *(fails: returned exit code 8)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b07a4810832e8569b609e7653ac1