### PR TITLE
chore: raise phpstan level

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 5
+    level: 7
     paths:
         - src
         - tests


### PR DESCRIPTION
## Summary
- bump PHPStan analysis level from 5 to 7

## Testing
- `composer test`
- `composer stan` *(fails: invalid entries in ignoreErrors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b0585974832ea556082db77ea3f8