### PR TITLE
Raise PHPStan level to 7

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 5
+    level: 7
     paths:
         - src
         - tests


### PR DESCRIPTION
## Summary
- raise PHPStan static analysis level to 7

## Testing
- `composer lint` *(fails: Script PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --diff handling the lint event returned with error code 8)*
- `composer test`
- `composer stan` *(fails: Path ".../tests/MetricsEndpointTest.php" is neither a directory nor a file path nor a fnmatch pattern)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bf6dcce8832e801cb2ed9e3cf3d4