### PR TITLE
Improve typing and integration tests

### DIFF
--- a/src/Console/RunDataHealthCommand.php
+++ b/src/Console/RunDataHealthCommand.php
@@ -12,7 +12,7 @@ class RunDataHealthCommand extends Command
     protected $signature = 'data-health-poc:run {--rule=}';
     protected $description = 'Run PoC data health checks (single-tenant)';
 
-    public function handle()
+    public function handle(): int
     {
         $rules = Rule::query()->where('enabled', true)->get()->keyBy('code');
 
@@ -23,8 +23,9 @@ class RunDataHealthCommand extends Command
 
         $summary = [];
 
+
         foreach ($configured as $code => $class) {
-            if ($target && strcasecmp($target, $code) !== 0) {
+            if (is_string($target) && $target !== '' && strcasecmp($target, $code) !== 0) {
                 continue;
             }
             if (! $rules->has($code)) {

--- a/src/Contracts/Rule.php
+++ b/src/Contracts/Rule.php
@@ -9,8 +9,12 @@ interface Rule
     public static function code(): string;
     public static function name(): string;
 
-    /** Return collection of associative arrays:
+    /**
+     * Return collection of associative arrays:
      * ['entity_type','entity_id','period_key', 'payload'=>[], 'hash']
+     *
+     * @param array<string, mixed> $options
+     * @return Collection<int, array<string, mixed>>
      */
     public function evaluate(array $options = []): Collection;
 }

--- a/src/Http/MetricsController.php
+++ b/src/Http/MetricsController.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\DB;
 
 class MetricsController extends Controller
 {
-    public function __invoke()
+    public function __invoke(): Response
     {
         $series = DB::table('dhp_results')
             ->selectRaw('rule_code, COUNT(*) as cnt')

--- a/src/Models/Result.php
+++ b/src/Models/Result.php
@@ -8,5 +8,9 @@ class Result extends Model
 {
     protected $table = 'dhp_results';
     protected $guarded = [];
+
+    /**
+     * @var array<string, string>
+     */
     protected $casts = ['payload' => 'array'];
 }

--- a/src/Models/Rule.php
+++ b/src/Models/Rule.php
@@ -8,5 +8,9 @@ class Rule extends Model
 {
     protected $table = 'dhp_rules';
     protected $guarded = [];
+
+    /**
+     * @var array<string, string>
+     */
     protected $casts = ['options' => 'array', 'enabled' => 'bool'];
 }

--- a/src/Rules/DuesOverMaxRule.php
+++ b/src/Rules/DuesOverMaxRule.php
@@ -17,6 +17,10 @@ class DuesOverMaxRule implements RuleContract
         return 'Dues amount exceeds configured maximum';
     }
 
+    /**
+     * @param array<string, mixed> $opt
+     * @return Collection<int, array<string, mixed>>
+     */
     public function evaluate(array $opt = []): Collection
     {
         $multiplier = (float)($opt['multiplier'] ?? 2.0);

--- a/src/Rules/DuplicateMonthlyChargesRule.php
+++ b/src/Rules/DuplicateMonthlyChargesRule.php
@@ -17,6 +17,10 @@ class DuplicateMonthlyChargesRule implements RuleContract
         return 'Duplicate charges in same month';
     }
 
+    /**
+     * @param array<string, mixed> $opt
+     * @return Collection<int, array<string, mixed>>
+     */
     public function evaluate(array $opt = []): Collection
     {
         $periodStart = $opt['period_start'] ?? null;

--- a/tests/Integration/RunDataHealthCommandTest.php
+++ b/tests/Integration/RunDataHealthCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase;
@@ -45,7 +46,7 @@ class RunDataHealthCommandTest extends TestCase
             $table->timestamps();
         });
 
-        $this->artisan('migrate', ['--database' => 'testing'])->run();
+        Artisan::call('migrate', ['--database' => 'testing']);
         (new DataHealthPocSeeder())->run();
     }
 
@@ -67,7 +68,8 @@ class RunDataHealthCommandTest extends TestCase
             ['id' => 2, 'member_id' => 1, 'period_ym' => '2025-01', 'type' => 'dues', 'amount' => 60],
         ]);
 
-        $this->artisan('data-health-poc:run')->assertExitCode(0);
+        $exit = Artisan::call('data-health-poc:run');
+        $this->assertSame(0, $exit);
 
         $this->assertDatabaseHas('dhp_results', [
             'rule_code' => 'DUE_OVER_MAX',
@@ -84,7 +86,8 @@ class RunDataHealthCommandTest extends TestCase
         DB::table('charges')->where('id', 1)->update(['amount' => 80]);
         DB::table('charges')->where('id', 2)->delete();
 
-        $this->artisan('data-health-poc:run')->assertExitCode(0);
+        $exit = Artisan::call('data-health-poc:run');
+        $this->assertSame(0, $exit);
 
         $this->assertDatabaseHas('dhp_results', [
             'rule_code' => 'DUE_OVER_MAX',


### PR DESCRIPTION
## Summary
- add explicit return types and generic annotations for rules and models
- tighten RunDataHealthCommand option handling
- stabilize integration test by invoking commands via Artisan facade

## Testing
- `composer lint`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c06020f8832ebc3352b29c181042