### PR TITLE
Fix coverage config for PHPUnit

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,6 +4,9 @@
          colors="true"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
     <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
         <report>
             <clover outputFile="coverage/clover.xml"/>
             <html outputDirectory="coverage/html"/>


### PR DESCRIPTION
## Summary
- include src directory in PHPUnit coverage configuration so `composer test:cov` collects coverage

## Testing
- `composer test`
- `XDEBUG_MODE=coverage php8.3 vendor/bin/pest --coverage --min=70 --coverage-html=coverage/html --coverage-clover=coverage/clover.xml`

------
https://chatgpt.com/codex/tasks/task_e_68a1c460c4b8832ebcf37681ba1f3dcc