### PR TITLE
feat: add Cloud Run deployment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,26 @@ jobs:
         with:
           name: coverage-html
           path: coverage/html
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+      - uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+      - name: Build and push image
+        run: |
+          gcloud builds submit --tag gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CLOUD_RUN_SERVICE }}:${{ github.sha }}
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy ${{ secrets.CLOUD_RUN_SERVICE }} \
+            --image gcr.io/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.CLOUD_RUN_SERVICE }}:${{ github.sha }} \
+            --region ${{ secrets.CLOUD_RUN_REGION }} \
+            --platform managed \
+            --allow-unauthenticated

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,27 @@
+# CI/CD and Deployment Setup
+
+This project ships with a GitHub Actions workflow that runs the test suite and, on pushes to the `main` branch, builds and deploys a container to **Google Cloud Run**.
+
+## GitHub configuration
+
+Create the following secrets in the repository settings:
+
+| Secret | Description |
+|--------|-------------|
+| `GCP_PROJECT_ID` | Google Cloud project ID hosting the service. |
+| `GCP_SA_KEY` | JSON key for a service account with deploy permissions. |
+| `CLOUD_RUN_SERVICE` | Name of the Cloud Run service to deploy. |
+| `CLOUD_RUN_REGION` | Region for the Cloud Run service (e.g. `us-central1`). |
+
+## Google Cloud configuration
+
+1. **Enable APIs** – Cloud Run, Cloud Build, Artifact Registry.
+2. **Service Account** – create one and grant roles:
+   - `Cloud Run Admin`
+   - `Cloud Build Service Account`
+   - `Artifact Registry Reader`
+   - `Service Account User`
+3. **Service Account Key** – generate a JSON key and save it as the `GCP_SA_KEY` GitHub secret.
+4. **Cloud Run service** – create (or let the first deploy create) a service matching `CLOUD_RUN_SERVICE` in the target region.
+
+Once configured, pushing to `main` will run tests and, if they succeed, deploy the latest container image to Cloud Run.


### PR DESCRIPTION
## Summary
- extend CI workflow with job that builds and deploys to Google Cloud Run on pushes to `main`
- document required GitHub secrets and Google Cloud setup

## Testing
- `composer lint`
- `composer stan`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a409cd6dbc832eb5474942418dbb92